### PR TITLE
feat: setup repo from fork, upgrade dependencies, setup GH actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*                @netlify/ecosystem-pod-composable-tooling

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+          # - 0.12
+          # - 4.x
+          # - 6.x
+          - 8.x # minimum as readdirp 3.x uses object spread
+          - 14.x
+          - 20.x
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install packages
+        run: npm install
+      - name: Test
+        run: npm run test:cov
+      # - name: Upload coverage
+      #   run: |
+      #     npm install -g codecov.io
+      #     cat ./coverage/lcov.info | codecov

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ coverage/
 tmp/
 npm-debug.log*
 .DS_Store
+.vscode
+!.vscode/launch.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-node_js:
-- "0.12"
-- "4"
-sudo: false
-language: node_js
-script: "npm run test:cov"
-after_script: "npm i -g codecov.io && cat ./coverage/lcov.info | codecov"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # copy-template-dir
 [![NPM version][npm-image]][npm-url]
-[![build status][travis-image]][travis-url]
+[![build status][github-actions-image]][github-actions-url]
 [![Test coverage][codecov-image]][codecov-url]
 [![Downloads][downloads-image]][downloads-url]
 [![js-standard-style][standard-image]][standard-url]
@@ -51,8 +51,8 @@ paths to created files if there were no errors.
 
 [npm-image]: https://img.shields.io/npm/v/copy-template-dir.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/copy-template-dir
-[travis-image]: https://img.shields.io/travis/yoshuawuyts/copy-template-dir/master.svg?style=flat-square
-[travis-url]: https://travis-ci.org/yoshuawuyts/copy-template-dir
+[github-actions-image]: https://img.shields.io/github/actions/workflow/status/yoshuawuyts/copy-template-dir/test.yml?style=flat-square
+[github-actions-url]: https://github.com/yoshuawuyts/copy-template-dir/actions
 [codecov-image]: https://img.shields.io/codecov/c/github/yoshuawuyts/copy-template-dir/master.svg?style=flat-square
 [codecov-url]: https://codecov.io/github/yoshuawuyts/copy-template-dir
 [downloads-image]: http://img.shields.io/npm/dm/copy-template-dir.svg?style=flat-square

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function copyTemplateDir (srcDir, outDir, vars, cb) {
   mkdirp(outDir, function (err) {
     if (err) return cb(err)
 
-    const rs = readdirp({ root: srcDir })
+    const rs = readdirp(srcDir)
     const streams = []
     const createdFiles = []
 
@@ -56,7 +56,7 @@ function writeFile (outDir, vars, file) {
   return function (done) {
     const fileName = file.path
     const inFile = file.fullPath
-    const parentDir = file.parentDir
+    const parentDir = path.dirname(file.path)
     const outFile = path.join(outDir, maxstache(removeUnderscore(fileName), vars))
 
     mkdirp(path.join(outDir, maxstache(parentDir, vars)), function (err) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const eos = require('end-of-stream')
 const readdirp = require('readdirp')
 const assert = require('assert')
 const mkdirp = require('mkdirp')
-const noop = require('noop2')
 const path = require('path')
 const pump = require('pump')
 const fs = require('graceful-fs')
@@ -16,7 +15,7 @@ module.exports = copyTemplateDir
 // (str, str, obj, fn) -> null
 function copyTemplateDir (srcDir, outDir, vars, cb) {
   if (!cb) {
-    if (!vars) vars = noop
+    if (!vars) vars = function () {}
     cb = vars
     vars = {}
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "maxstache": "^1.0.7",
     "maxstache-stream": "^1.0.4",
     "mkdirp": "^0.5.6",
-    "noop2": "^2.0.0",
     "pump": "^1.0.3",
     "readdirp": "^2.0.0",
     "run-parallel": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "maxstache-stream": "^1.0.4",
     "mkdirp": "^0.5.6",
     "pump": "^1.0.3",
-    "readdirp": "^2.0.0",
+    "readdirp": "^3.6.0",
     "run-parallel": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "end-of-stream": "^1.1.0",
-    "graceful-fs": "^4.1.3",
-    "maxstache": "^1.0.0",
-    "maxstache-stream": "^1.0.0",
-    "mkdirp": "^0.5.1",
+    "end-of-stream": "^1.4.4",
+    "graceful-fs": "^4.2.11",
+    "maxstache": "^1.0.7",
+    "maxstache-stream": "^1.0.4",
+    "mkdirp": "^0.5.6",
     "noop2": "^2.0.0",
-    "pump": "^1.0.0",
+    "pump": "^1.0.3",
     "readdirp": "^2.0.0",
-    "run-parallel": "^1.1.4"
+    "run-parallel": "^1.2.0"
   },
   "devDependencies": {
     "concat-stream": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "run-parallel": "^1.1.4"
   },
   "devDependencies": {
-    "concat-stream": "^1.5.0",
-    "dependency-check": "^2.5.1",
-    "istanbul": "^0.3.21",
-    "rimraf": "^2.4.3",
-    "standard": "^5.3.1",
-    "tape": "^4.2.0"
+    "concat-stream": "^1.6.2",
+    "dependency-check": "^2.10.1",
+    "istanbul": "^0.3.22",
+    "rimraf": "^2.7.1",
+    "standard": "^17.1.0",
+    "tape": "^4.16.2"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "copy-template-dir",
-  "version": "1.4.0",
+  "name": "@netlify/copy-template-dir",
+  "version": "0.0.1",
   "description": "High throughput template dir writes",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "test": "standard && npm run deps && NODE_ENV=test node test",
     "test:cov": "standard && npm run deps && NODE_ENV=test istanbul cover test/index.js"
   },
-  "repository": "yoshuawuyts/copy-template-dir",
+  "repository": "netlify/copy-template-dir",
   "keywords": [
     "template",
     "directory",

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ test('should write a bunch of files', function (t) {
       return path.relative(outDir, filePath)
     }), 'reported as created')
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const names = arr.map(function (file) { return file.path })
@@ -61,7 +61,7 @@ test('should inject context variables strings', function (t) {
   copy(inDir, outDir, { foo: 'bar' }, function (err) {
     t.error(err)
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const file = path.join(outDir, '1.txt')
@@ -87,7 +87,7 @@ test('should inject context variables strings into filenames', function (t) {
   copy(inDir, outDir, { foo: 'bar' }, function (err) {
     t.error(err)
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const file = path.join(outDir, 'bar.txt')
@@ -110,7 +110,7 @@ test('should inject context variables strings into directory names', function (t
   copy(inDir, outDir, { foo: 'bar' }, function (err) {
     t.error(err)
 
-    readdirp({ root: outDir }).pipe(concat({ object: true }, function (arr) {
+    readdirp(outDir).pipe(concat({ object: true }, function (arr) {
       t.ok(Array.isArray(arr), 'is array')
 
       const dir = path.join(outDir, 'bar')


### PR DESCRIPTION
## Context 

We are using the [copy-template-dir](https://github.com/yoshuawuyts/copy-template-dir) library in the Netlify CLI, and it being outdated is causing deprecated warnings. Since it's no longer maintained, we are forking it so we can upgrade the dependencies and maintain it at Netlify.

## What this PR does 

It sets up the repo to be maintained by Netlify and brings the following PRs from the original repo:

- Upgrades dependencies ([see original PR](https://github.com/yoshuawuyts/copy-template-dir/pull/17))
- Switches Travis to GH actions ([see original PR](https://github.com/yoshuawuyts/copy-template-dir/pull/18))